### PR TITLE
Fix documentation for slaves

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 	Suggestion for testing: set 172.16.0.0/12 as BIND_SLAVE_IP so any container in the default docker network will be able to perform zone transfers.
 
 *Run the slave:*
-- docker run -ti --name bindslave -e BIND_MASTER_IP=$(docker inspect -f '{{ .NetworkSettings.IPAddress }}' bindmaster) -v /path/to/your/zones/folder:/etc/bind/zones kpeiruza/lpic2-bind9-master-slave 
+- docker run -ti --name bindslave -e BIND_MASTER=false -e BIND_MASTER_IP=$(docker inspect -f '{{ .NetworkSettings.IPAddress }}' bindmaster) -v /path/to/your/zones/folder:/etc/bind/zones kpeiruza/lpic2-bind9-master-slave 
 
 Once started, you can check the DNS resolution with host or dig pointing to the container's IP:
 

--- a/named.conf.options
+++ b/named.conf.options
@@ -21,7 +21,8 @@ options {
 	//========================================================================
 	dnssec-validation no;
 //	Whom do we allow to resolve 3rd party domains to us. Needs zone ".".
-	allow-recursion { ::1;127.0.0.1;};
+        recursion yes;
+        allow-recursion { ::1; 127.0.0.1; 10.0.0.0/8; 172.16.0.0/12; 192.168.0.0/16; };
 //	We close AXFR by default. Here you could list all your secondary DNS IPs
 	allow-transfer { none; };
 


### PR DESCRIPTION
BIND_MASTER=true is explicitly set in the Dockerfile.

Therefore, to create a slave zone you have to set BIND_MASTER=false, hence this change.